### PR TITLE
some changes

### DIFF
--- a/floyd_with_path.py
+++ b/floyd_with_path.py
@@ -1,0 +1,114 @@
+from typing import Dict, List, Optional, Tuple, Union
+
+def floyd_warshall(graph: np.ndarray, path_reconstruction=False) -> Union[np.ndarray,
+                                                                          Optional[Tuple[np.ndarray, np.ndarray]]]:
+    """Finds all shortest paths in a weighted graph. Works with positive and negative weights,
+    but not with negative cycles.
+    Time complexity O(|V|^3)
+    Space complexity O(|V|^3)
+    Args:
+        graph (np.ndarray): Adjacency matrix of the graph as numpy ndarray.
+        path_reconstruction (bool, optional): Whether to calculate and output the matrix needed for path reconstruction.
+    Return:
+        np.matrix: Adjacency matrix showing all shortest paths.
+        np.matrix (optional): Adjacency matrix needed for path reconstruction.
+    Examples:
+        >>> graph = np.asarray([[0, np.inf, -2, np.inf], [4, 0, 3, np.inf], [np.inf, np.inf, 0, 2], [np.inf, -1, np.inf, 0]])
+        >>> shortest_paths = floyd_warshall(graph)
+        >>> print(shortest_paths)
+        [[ 0. -1. -2.  0.]
+         [ 4.  0.  2.  4.]
+         [ 5.  1.  0.  2.]
+         [ 3. -1.  1.  0.]]
+    """
+    assert graph.shape[0] == graph.shape[1], "Input matrix must be a square adjacency matrix"
+
+    dist_matrix = np.full(graph.shape, np.inf)
+    if path_reconstruction:
+        next_matrix = np.full(graph.shape, 0)
+
+    for edge, weight in np.ndenumerate(graph):
+        dist_matrix[edge[0], edge[1]] = weight
+
+        if path_reconstruction:
+            next_matrix[edge[0], edge[1]] = edge[1]
+
+    np.fill_diagonal(dist_matrix, 0)
+    if path_reconstruction:
+        np.fill_diagonal(next_matrix, range(next_matrix.shape[0]))
+
+    for k in range(0, graph.shape[0]):
+        for i in range(0, graph.shape[0]):
+            for j in range(0, graph.shape[0]):
+                if dist_matrix[i][j] > dist_matrix[i][k] + dist_matrix[k][j]:
+                    dist_matrix[i][j] = dist_matrix[i][k] + dist_matrix[k][j]
+                    if path_reconstruction:
+                        next_matrix[i][j] = next_matrix[i][k]
+
+    if path_reconstruction:
+        return dist_matrix, next_matrix
+    return dist_matrix
+
+
+def shortest_path(graph: np.ndarray, *waypoints, pretty=False) -> Union[str, None, Tuple[List[int], Dict[Tuple[int, int], int]]]:
+    """Reconstructs shortest path between multiple nodes
+    Args:
+        graph (np.matrix): Adjacency matrix of the graph as numpy matrix.
+        waypoints: waypoints between which the shortest path should get calculated.
+        pretty (bool): Whether to pretty print path or return raw path
+    Note:
+        if not path exists between all of the waypoints not path will get calculated
+    Return:
+        str: Formatted text output showing input, shortest path and cost of the shortest path
+        Tuple[List[int], Dict[Tuple[int, int], int]]: Tuple list with indices of shortest path and dictionary which
+        contains the cost for every step of the shortest path
+    Example:
+        >>> graph = np.asarray([[0, np.inf, -2, np.inf], [4, 0, 3, np.inf], [np.inf, np.inf, 0, 2], [np.inf, -1, np.inf, 0]])
+        >>> path = shortest_path(graph, 0, 1, 3)
+        >>> print(path)
+        ([0, 2, 3, 1, 0, 2, 3], {(0, 2): -2.0, (2, 3): 2.0, (3, 1): -1.0, (1, 0): 4.0})
+    """
+    dist_matrix, path_matrix = floyd_warshall(graph, path_reconstruction=True)
+
+    assert len(waypoints) > 0, "No waypoints supplied."
+    assert all(isinstance(waypoint, int) for waypoint in waypoints), "False datatype for at least one waypoint " \
+                                                                     "(int needed)"
+
+    for i in range(len(waypoints) - 1):
+        try:
+            path_matrix[waypoints[i]][waypoints[i + 1]]
+        except IndexError:
+            return "IndexError: Certain waypoint nodes are not part of the input graph"
+
+    def calculate_shortest_path():
+        path = [waypoints[0]]
+
+        for i in range(len(waypoints) - 1):
+            u = waypoints[i]
+            v = waypoints[i + 1]
+            while u != v:
+                u = path_matrix[u][v]
+                path.append(u)
+
+        return path
+
+    def pprint_path():
+        _waypoints = " ⟶ ".join([str(node) for node in waypoints])
+        _shortest_path = " ⟶ ".join([str(node) for node in path])
+        _cost = '\n'.join(
+            [f"{node[0]} ⟶ {node[1]} ({dist_matrix[node[0]][node[1]]})" for node in list(zip(path, path[1:]))])
+        return f"== Waypoints ==\n{_waypoints}\n\n==Shortest Path ==\n{_shortest_path}\n\n== Cost ==\n{_cost}"
+
+    def calc_path_costs():
+        return {(node[0], node[1]): dist_matrix[node[0]][node[1]] for node in list(zip(path, path[1:]))}
+
+    path = calculate_shortest_path()
+    if pretty:
+        return print(f"{pprint_path()}\nTotal Cost: {sum(calc_path_costs().values())}")
+    return path, calc_path_costs()
+
+graph = np.asarray([[0, np.inf, -2, np.inf], [4, 0, 3, np.inf], [np.inf, np.inf, 0, 2], [np.inf, -1, np.inf, 0]])
+dist=floyd_warshall(graph)
+path = shortest_path(graph, 0, 1)
+print(dist)
+print(path)

--- a/node_info.txt
+++ b/node_info.txt
@@ -1,0 +1,332 @@
+     1 "Wiley Post-Will Rogers Mem"             0.4407    0.0910    0.5000
+     2 "Deadhorse"                              0.4830    0.1014    0.5000
+     3 "Ralph Wien Memorial"                    0.4110    0.1330    0.5000
+     4 "Fairbanks Intl"                         0.4861    0.1528    0.5000
+     5 "Nome"                                   0.3965    0.1557    0.5000
+     6 "St Mary's"                              0.4074    0.1791    0.5000
+     7 "Aniak"                                  0.4266    0.1837    0.5000
+     8 "Anchorage Intl"                         0.4752    0.1876    0.5000
+     9 "Tuluksak"                               0.4193    0.1883    0.5000
+    10 "Akiachak"                               0.4169    0.1901    0.5000
+    11 "Akiak"                                  0.4180    0.1901    0.5000
+    12 "Kwethluk"                               0.4169    0.1911    0.5000
+    13 "Bethel"                                 0.4149    0.1913    0.5000
+    14 "Napaskiak"                              0.4152    0.1921    0.5000
+    15 "Napakiak"                               0.4142    0.1922    0.5000
+    16 "Merle K (Mudhole) Smith"                0.4982    0.1941    0.5000
+    17 "Tuntutuliak"                            0.4107    0.1956    0.5000
+    18 "Eek"                                    0.4140    0.1967    0.5000
+    19 "Kongiganak"                             0.4096    0.1992    0.5000
+    20 "Kwigillingok"                           0.4082    0.2003    0.5000
+    21 "Quinhagak"                              0.4147    0.2011    0.5000
+    22 "Yakutat"                                0.5278    0.2035    0.5000
+    23 "Dillingham"                             0.4319    0.2079    0.5000
+    24 "King Salmon"                            0.4413    0.2114    0.5000
+    25 "Gustavus"                               0.5480    0.2138    0.5000
+    26 "Juneau Intl"                            0.5537    0.2145    0.5000
+    27 "Kodiak"                                 0.4625    0.2203    0.5000
+    28 "St Paul Island"                         0.3722    0.2259    0.5000
+    29 "Sitka"                                  0.5497    0.2270    0.5000
+    30 "Port Heiden"                            0.4312    0.2278    0.5000
+    31 "James A Johnson Petersburg"             0.5620    0.2293    0.5000
+    32 "Wrangell"                               0.5650    0.2324    0.5000
+    33 "Ketchikan Intl"                         0.5683    0.2432    0.5000
+    34 "Sand Point"                             0.4216    0.2435    0.5000
+    35 "Cold Bay"                               0.4104    0.2446    0.5000
+    36 "Unalaska"                               0.3909    0.2571    0.5000
+    37 "Eareckson As"                           0.2924    0.2684    0.5000
+    38 "Adak Naf"                               0.3395    0.2764    0.5000
+    39 "Bellingham Intl"                        0.6150    0.3059    0.5000
+    40 "Glacier Park Intl"                      0.6572    0.3105    0.5000
+    41 "Minot Intl"                             0.7233    0.3110    0.5000
+    42 "William R Fairchild Intl"               0.6101    0.3123    0.5000
+    43 "Grand Forks Afb"                        0.7430    0.3138    0.5000
+    44 "Grand Forks Intl"                       0.7442    0.3139    0.5000
+    45 "Spokane Intl"                           0.6405    0.3171    0.5000
+    46 "Great Falls Intl"                       0.6719    0.3184    0.5000
+    47 "Seattle-Tacoma Intl"                    0.6162    0.3188    0.5000
+    48 "Pangborn Memorial"                      0.6269    0.3192    0.5000
+    49 "Grant County"                           0.6314    0.3210    0.5000
+    50 "Missoula Intll"                         0.6580    0.3238    0.5000
+    51 "Hector Intll"                           0.7460    0.3238    0.5000
+    52 "Duluth Intl"                            0.7696    0.3245    0.5000
+    53 "Bismarck Muni"                          0.7260    0.3252    0.5000
+    54 "Pullman/Moscow Regional"                0.6427    0.3254    0.5000
+    55 "Helena Regional"                        0.6688    0.3268    0.5000
+    56 "Yakima Air Terminal"                    0.6252    0.3271    0.5000
+    57 "Marquette County"                       0.7931    0.3275    0.5000
+    58 "Lewiston-Nez Perce County"              0.6431    0.3290    0.5000
+    59 "Tri-Cities"                             0.6324    0.3300    0.5000
+    60 "Walla Walla Regional"                   0.6367    0.3317    0.5000
+    61 "Bert Mooney"                            0.6662    0.3330    0.5000
+    62 "Billings Logan Intl"                    0.6863    0.3344    0.5000
+    63 "Gallatin Field"                         0.6730    0.3347    0.5000
+    64 "Eastern Oregon Regional At Pen"         0.6338    0.3355    0.5000
+    65 "Portland Intl"                          0.6147    0.3365    0.5000
+    66 "Mcnary Fld"                             0.6127    0.3430    0.5000
+    67 "Minneapolis-St Paul Intl/Wold-"         0.7644    0.3432    0.5000
+    68 "Bangor Intl"                            0.8885    0.3439    0.5000
+    69 "Central Wisconsin"                      0.7824    0.3442    0.5000
+    70 "Cherry Capital"                         0.8032    0.3446    0.5000
+    71 "Austin Straubel Intll"                  0.7903    0.3470    0.5000
+    72 "Burlington Intl"                        0.8665    0.3472    0.5000
+    73 "Outagamie County"                       0.7883    0.3492    0.5000
+    74 "Roberts Field"                          0.6221    0.3492    0.5000
+    75 "Mahlon Sweet Field"                     0.6116    0.3505    0.5000
+    76 "Rapid City Regional"                    0.7142    0.3512    0.5000
+    77 "Wittman Regional"                       0.7881    0.3518    0.5000
+    78 "Rochester Intll"                        0.7680    0.3525    0.5000
+    79 "La Crosse Muni"                         0.7743    0.3528    0.5000
+    80 "Portland Intl Jetport"                  0.8810    0.3550    0.5000
+    81 "Jackson Hole"                           0.6751    0.3554    0.5000
+    82 "Joe Foss Field"                         0.7464    0.3557    0.5000
+    83 "Boise Air Terminal /Gowen Fld/"         0.6472    0.3558    0.5000
+    84 "Mbs Intll"                              0.8109    0.3561    0.5000
+    85 "Fanning Field"                          0.6683    0.3563    0.5000
+    86 "Friedman Memorial"                      0.6570    0.3564    0.5000
+    87 "North Bend Muni"                        0.6063    0.3572    0.5000
+    88 "Muskegon County"                        0.7999    0.3596    0.5000
+    89 "Oneida County"                          0.8552    0.3598    0.5000
+    90 "Dane County Regional-Truax Fie"         0.7841    0.3599    0.5000
+    91 "Greater Rochester Intl"                 0.8435    0.3601    0.5000
+    92 "Syracuse Hancock Intl"                  0.8515    0.3602    0.5000
+    93 "Bishop Intll"                           0.8126    0.3615    0.5000
+    94 "General Mitchell Intll"                 0.7914    0.3617    0.5000
+    95 "Greater Buffalo Intl"                   0.8381    0.3618    0.5000
+    96 "Manchester"                             0.8753    0.3619    0.5000
+    97 "Pocatello Regional"                     0.6657    0.3621    0.5000
+    98 "Natrona County Intl"                    0.6969    0.3621    0.5000
+    99 "Kent County Intl"                       0.8035    0.3623    0.5000
+   100 "Capital City"                           0.8083    0.3633    0.5000
+   101 "Albany County"                          0.8632    0.3636    0.5000
+   102 "Waterloo Muni"                          0.7685    0.3655    0.5000
+   103 "Tompkins County"                        0.8497    0.3661    0.5000
+   104 "Twin Falls-Sun Valley Regional"         0.6560    0.3662    0.5000
+   105 "Detroit City"                           0.8163    0.3669    0.5000
+   106 "Sioux Gateway"                          0.7482    0.3669    0.5000
+   107 "Dubuque Regional"                       0.7771    0.3669    0.5000
+   108 "Rogue Valley Intl- M"                   0.6133    0.3672    0.5000
+   109 "General Edward Lawrence Logan"          0.8775    0.3673    0.5000
+   110 "Worcester Muni"                         0.8730    0.3682    0.5000
+   111 "Kalamazoo/Battle Creek Interna"         0.8034    0.3685    0.5000
+   112 "Detroit Metropolitan Wayne Cou"         0.8146    0.3687    0.5000
+   113 "Binghamton Regional/Edwin A Li"         0.8521    0.3688    0.5000
+   114 "Greater Rockford"                       0.7853    0.3689    0.5000
+   115 "Elmira/Corning Regional"                0.8475    0.3692    0.5000
+   116 "Klamath Falls Intll"                    0.6191    0.3693    0.5000
+   117 "Erie Intl"                              0.8308    0.3700    0.5000
+   118 "Chicago O'hare Intl"                    0.7914    0.3710    0.5000
+   119 "Bradley Intl"                           0.8689    0.3714    0.5000
+   120 "Cedar Rapids Muni"                      0.7720    0.3719    0.5000
+   121 "William B. Heilig Field"                0.7115    0.3720    0.5000
+   122 "Merrill C Meigs"                        0.7929    0.3721    0.5000
+   123 "Chicago Midway"                         0.7922    0.3728    0.5000
+   124 "Jack Mc Namara Field"                   0.6064    0.3729    0.5000
+   125 "Theodore Francis Green State"           0.8753    0.3734    0.5000
+   126 "Michiana Rgnl Transportation C"         0.7995    0.3736    0.5000
+   127 "Toledo Express"                         0.8123    0.3747    0.5000
+   128 "Des Moines Intl"                        0.7621    0.3752    0.5000
+   129 "Stewart Int'l"                          0.8617    0.3755    0.5000
+   130 "Quad-City"                              0.7781    0.3760    0.5000
+   131 "Cleveland-Hopkins Intl"                 0.8222    0.3764    0.5000
+   132 "Wilkes-Barre/Scranton Intl"             0.8534    0.3771    0.5000
+   133 "Eppley Airfield"                        0.7507    0.3774    0.5000
+   134 "Tweed-New Haven"                        0.8679    0.3778    0.5000
+   135 "Youngstown-Warren Regional"             0.8282    0.3779    0.5000
+   136 "Westchester County"                     0.8637    0.3797    0.5000
+   137 "Fort Wayne Intll"                       0.8052    0.3805    0.5000
+   138 "Arcata"                                 0.6070    0.3805    0.5000
+   139 "Akron-Canton Regional"                  0.8243    0.3811    0.5000
+   140 "Lincoln Muni"                           0.7463    0.3818    0.5000
+   141 "University Park"                        0.8426    0.3818    0.5000
+   142 "Elko Muni-J.C. Harris Field"            0.6494    0.3820    0.5000
+   143 "Long Island Mac Arthur"                 0.8668    0.3823    0.5000
+   144 "Salt Lake City Intl"                    0.6688    0.3824    0.5000
+   145 "Burlington Regional"                    0.7750    0.3824    0.5000
+   146 "La Guardia"                             0.8629    0.3825    0.5000
+   147 "Newark Intl"                            0.8614    0.3833    0.5000
+   148 "Greater Peoria Regional"                0.7823    0.3835    0.5000
+   149 "Lehigh Valley Intll"                    0.8549    0.3837    0.5000
+   150 "John F Kennedy Intl"                    0.8633    0.3838    0.5000
+   151 "Redding Muni"                           0.6163    0.3850    0.5000
+   152 "Pittsburgh Intll"                       0.8305    0.3852    0.5000
+   153 "Yampa Valley"                           0.6930    0.3853    0.5000
+   154 "Bloomington/Normal"                     0.7862    0.3853    0.5000
+   155 "Purdue University"                      0.7963    0.3859    0.5000
+   156 "Mercer County"                          0.8581    0.3872    0.5000
+   157 "Harrisburg Intll"                       0.8481    0.3880    0.5000
+   158 "University Of Illinois-Willard"         0.7895    0.3895    0.5000
+   159 "Port Columbus Intl"                     0.8169    0.3899    0.5000
+   160 "Quincy Muni Baldwin Field"              0.7746    0.3904    0.5000
+   161 "James M Cox Dayton Intl"                0.8102    0.3908    0.5000
+   162 "Philadelphia Intl"                      0.8559    0.3911    0.5000
+   163 "Capital"                                0.7824    0.3914    0.5000
+   164 "Decatur"                                0.7865    0.3915    0.5000
+   165 "Chico Muni"                             0.6185    0.3918    0.5000
+   166 "Stapleton Intl"                         0.7049    0.3920    0.5000
+   167 "Indianapolis Intl"                      0.7996    0.3926    0.5000
+   168 "Eagle County Regional"                  0.6946    0.3933    0.5000
+   169 "Reno/Tahoe Intll"                       0.6291    0.3947    0.5000
+   170 "Atlantic City Intll"                    0.8593    0.3951    0.5000
+   171 "Hulman Regional"                        0.7944    0.3951    0.5000
+   172 "Kansas City Intl"                       0.7567    0.3966    0.5000
+   173 "Aspen-Pitkin Co/Sardy Field"            0.6948    0.3973    0.5000
+   174 "Baltimore-Washington Intl"              0.8486    0.3978    0.5000
+   175 "Walker Field"                           0.6864    0.3983    0.5000
+   176 "Cincinnati/Northern Kentucky I"         0.8079    0.3990    0.5000
+   177 "Washington Dulles Intl"                 0.8446    0.4000    0.5000
+   178 "Lake Tahoe"                             0.6280    0.4005    0.5000
+   179 "Washington National"                    0.8467    0.4008    0.5000
+   180 "Columbia Regional"                      0.7694    0.4012    0.5000
+   181 "City Of Colorado Springs Muni"          0.7059    0.4013    0.5000
+   182 "Lambert-St Louis Intl"                  0.7789    0.4018    0.5000
+   183 "Sacramento Metropolitan"                0.6198    0.4023    0.5000
+   184 "Gunnison County"                        0.6945    0.4039    0.5000
+   185 "Sonoma County"                          0.6136    0.4041    0.5000
+   186 "Yeager"                                 0.8235    0.4054    0.5000
+   187 "Tri-State/Milton J.Ferguson Fi"         0.8186    0.4055    0.5000
+   188 "Pueblo Memorial"                        0.7069    0.4062    0.5000
+   189 "Louisville Intl"                        0.8024    0.4073    0.5000
+   190 "Charlottesville-Albemarle"              0.8395    0.4077    0.5000
+   191 "Evansville Regional"                    0.7933    0.4086    0.5000
+   192 "Blue Grass"                             0.8082    0.4086    0.5000
+   193 "Stockton Metropolitan"                  0.6216    0.4100    0.5000
+   194 "Greenbrier Valley"                      0.8296    0.4103    0.5000
+   195 "Williamson County Regional"             0.7858    0.4114    0.5000
+   196 "Forney Aaf"                             0.7698    0.4115    0.5000
+   197 "Metropolitan Oakland Intl"              0.6166    0.4117    0.5000
+   198 "Wichita Mid-Continent"                  0.7429    0.4123    0.5000
+   199 "Modesto City-County--Harry Sha"         0.6231    0.4126    0.5000
+   200 "Mammoth Lakes"                          0.6339    0.4126    0.5000
+   201 "San Francisco Intl"                     0.6159    0.4126    0.5000
+   202 "Richmond Intll"                         0.8453    0.4137    0.5000
+   203 "San Jose Intll"                         0.6181    0.4151    0.5000
+   204 "Roanoke Regional/Woodrum Field"         0.8318    0.4154    0.5000
+   205 "Merced Municipal/Macready Fiel"         0.6253    0.4158    0.5000
+   206 "Springfield Regional"                   0.7635    0.4162    0.5000
+   207 "Cape Girardeau Regional"                0.7829    0.4164    0.5000
+   208 "Durango-La Plata County"                0.6903    0.4171    0.5000
+   209 "Joplin Regional"                        0.7578    0.4171    0.5000
+   210 "Newport News/Williamsburg Inte"         0.8495    0.4173    0.5000
+   211 "Barkley Regional"                       0.7870    0.4180    0.5000
+   212 "Norfolk Intl"                           0.8510    0.4196    0.5000
+   213 "Fresno Air Terminal"                    0.6294    0.4207    0.5000
+   214 "Monterey Peninsula"                     0.6186    0.4225    0.5000
+   215 "Tri-Cities Regional Tn/Va"              0.8194    0.4236    0.5000
+   216 "Tulsa Intl"                             0.7507    0.4262    0.5000
+   217 "Nashville Intll"                        0.7976    0.4269    0.5000
+   218 "Piedmont Triad Intll"                   0.8320    0.4272    0.5000
+   219 "Mc Carran Intl"                         0.6526    0.4273    0.5000
+   220 "Drake Field"                            0.7595    0.4281    0.5000
+   221 "Raleigh-Durham Intll"                   0.8378    0.4293    0.5000
+   222 "Mc Ghee Tyson"                          0.8113    0.4299    0.5000
+   223 "Asheville Regional"                     0.8187    0.4335    0.5000
+   224 "Meadows Field"                          0.6327    0.4335    0.5000
+   225 "Will Rogers World"                      0.7420    0.4339    0.5000
+   226 "Fort Smith Regional"                    0.7585    0.4344    0.5000
+   227 "Kinston Regional Jetport At St"         0.8438    0.4345    0.5000
+   228 "San Luis Obispo County-Mc Ches"         0.6247    0.4354    0.5000
+   229 "Amarillo Intl"                          0.7211    0.4356    0.5000
+   230 "Charlotte/Douglas Intl"                 0.8268    0.4356    0.5000
+   231 "Flagstaff Pulliam"                      0.6704    0.4363    0.5000
+   232 "Memphis Intl"                           0.7808    0.4372    0.5000
+   233 "Albuquerque Intl"                       0.6961    0.4373    0.5000
+   234 "Lovell Field"                           0.8052    0.4373    0.5000
+   235 "Fayetteville Regional/Grannis"          0.8374    0.4377    0.5000
+   236 "Santa Maria Pub/Capt G Allan H"         0.6256    0.4386    0.5000
+   237 "Greenville-Spartanburg"                 0.8204    0.4386    0.5000
+   238 "Albert J Ellis"                         0.8438    0.4393    0.5000
+   239 "Adams Field"                            0.7694    0.4402    0.5000
+   240 "Huntsville Intl-Carl T Jones F"         0.7972    0.4411    0.5000
+   241 "Lawton Muni"                            0.7379    0.4418    0.5000
+   242 "Santa Barbara Muni"                     0.6288    0.4431    0.5000
+   243 "New Hanover Intll"                      0.8423    0.4446    0.5000
+   244 "Oxnard"                                 0.6320    0.4453    0.5000
+   245 "Burbank-Glendale-Pasadena"              0.6363    0.4453    0.5000
+   246 "Ontario Intl"                           0.6402    0.4467    0.5000
+   247 "Sheppard Afb/Wichita Falls Mun"         0.7375    0.4474    0.5000
+   248 "Los Angeles Intl"                       0.6361    0.4478    0.5000
+   249 "Columbia Metropolitan"                  0.8260    0.4478    0.5000
+   250 "Palm Springs Regional"                  0.6457    0.4489    0.5000
+   251 "Long Beach /Daugherty Field/"           0.6374    0.4490    0.5000
+   252 "Myrtle Beach Intl"                      0.8371    0.4503    0.5000
+   253 "John Wayne Airport-Orange Coun"         0.6388    0.4503    0.5000
+   254 "Lubbock Intl"                           0.7205    0.4504    0.5000
+   255 "The William B Hartsfield Atlan"         0.8091    0.4506    0.5000
+   256 "Birmingham Intl"                        0.7973    0.4514    0.5000
+   257 "Texarkana Regional-Webb Field"          0.7604    0.4524    0.5000
+   258 "Phoenix Sky Harbor Intl"                0.6686    0.4526    0.5000
+   259 "Bush Field"                             0.8216    0.4532    0.5000
+   260 "Charleston Afb/Intl"                    0.8314    0.4577    0.5000
+   261 "Dallas/Fort Worth Intl"                 0.7449    0.4578    0.5000
+   262 "Dallas Love Field"                      0.7458    0.4582    0.5000
+   263 "San Diego Intl-Lindbergh Fld"           0.6423    0.4593    0.5000
+   264 "Yuma Mcas/Yuma Intl"                    0.6554    0.4600    0.5000
+   265 "Columbus Metropolitan"                  0.8065    0.4614    0.5000
+   266 "Monroe Regional"                        0.7703    0.4614    0.5000
+   267 "Shreveport Regional"                    0.7612    0.4621    0.5000
+   268 "Abilene Regional"                       0.7314    0.4624    0.5000
+   269 "Gregg County"                           0.7567    0.4626    0.5000
+   270 "Tyler Pounds Field"                     0.7532    0.4629    0.5000
+   271 "Jackson Intll"                          0.7803    0.4634    0.5000
+   272 "Dannelly Field"                         0.7991    0.4635    0.5000
+   273 "Savannah Intll"                         0.8255    0.4651    0.5000
+   274 "Tucson Intl"                            0.6741    0.4652    0.5000
+   275 "Midland Intll"                          0.7186    0.4669    0.5000
+   276 "El Paso Intl"                           0.6973    0.4682    0.5000
+   277 "Waco Regional"                          0.7439    0.4700    0.5000
+   278 "Alexandria Esler Regional"              0.7690    0.4721    0.5000
+   279 "Mathis Field"                           0.7273    0.4725    0.5000
+   280 "Killeen Muni"                           0.7416    0.4751    0.5000
+   281 "Mobile Regional"                        0.7897    0.4788    0.5000
+   282 "Easterwood Field"                       0.7483    0.4798    0.5000
+   283 "Baton Rouge Metropolitan, Ryan"         0.7749    0.4803    0.5000
+   284 "Jacksonville Intl"                      0.8231    0.4807    0.5000
+   285 "Eglin Afb"                              0.7984    0.4808    0.5000
+   286 "Pensacola Regional"                     0.7951    0.4809    0.5000
+   287 "Tallahassee Regional"                   0.8095    0.4816    0.5000
+   288 "Robert Mueller Muni"                    0.7415    0.4826    0.5000
+   289 "Panama City-Bay Co Intl"                0.8027    0.4834    0.5000
+   290 "Lafayette Regional"                     0.7706    0.4835    0.5000
+   291 "Lake Charles Regional"                  0.7643    0.4842    0.5000
+   292 "New Orleans Intl/Moisant Fld/"          0.7794    0.4855    0.5000
+   293 "Houston Intercontinental"               0.7535    0.4856    0.5000
+   294 "Jefferson County"                       0.7602    0.4859    0.5000
+   295 "Gainesville Regional"                   0.8201    0.4884    0.5000
+   296 "William P Hobby"                        0.7538    0.4888    0.5000
+   297 "San Antonio Intl"                       0.7376    0.4899    0.5000
+   298 "Daytona Beach Intl"                     0.8263    0.4933    0.5000
+   299 "Orlando Intl"                           0.8250    0.5004    0.5000
+   300 "Melbourne Intll"                        0.8284    0.5036    0.5000
+   301 "Tampa Intl"                             0.8188    0.5048    0.5000
+   302 "St Petersburg/Clearwater Intl"          0.8180    0.5054    0.5000
+   303 "Corpus Christi Intl"                    0.7425    0.5067    0.5000
+   304 "Laredo Intl"                            0.7325    0.5089    0.5000
+   305 "Sarasota/Bradenton Intl"                0.8186    0.5103    0.5000
+   306 "Palm Beach Intl"                        0.8312    0.5171    0.5000
+   307 "Southwest Florida Intl"                 0.8227    0.5185    0.5000
+   308 "Rio Grande Valley Intl"                 0.7417    0.5215    0.5000
+   309 "Mc Allen Miller Intl"                   0.7388    0.5220    0.5000
+   310 "Fort Lauderdale/Hollywood Intl"         0.8309    0.5230    0.5000
+   311 "Miami Intl"                             0.8302    0.5256    0.5000
+   312 "Lihue"                                  0.4276    0.5621    0.5000
+   313 "Honolulu Intl"                          0.4348    0.5684    0.5000
+   314 "Molokai"                                0.4390    0.5700    0.5000
+   315 "Kapalua"                                0.4412    0.5718    0.5000
+   316 "Kahului"                                0.4424    0.5724    0.5000
+   317 "Lanai"                                  0.4398    0.5735    0.5000
+   318 "Keahole-Kona Intll"                     0.4444    0.5835    0.5000
+   319 "Hilo Intll"                             0.4495    0.5837    0.5000
+   320 "Rafael Hernandez"                       0.8972    0.5954    0.5000
+   321 "Luis Munoz Marin Intl"                  0.9029    0.5959    0.5000
+   322 "Cyril E King"                           0.9082    0.5969    0.5000
+   323 "Eugenio Maria De Hostos"                0.8971    0.5977    0.5000
+   324 "Mercedita"                              0.9001    0.6000    0.5000
+   325 "Alexander Hamilton"                     0.9091    0.6029    0.5000
+   326 "Johnston Atoll"                         0.3757    0.6122    0.5000
+   327 "Saipan Intl"                            0.1479    0.6276    0.5000
+   328 "Rota Intl"                              0.1454    0.6366    0.5000
+   329 "Guam Intll"                             0.1431    0.6432    0.5000
+   330 "Babelthuap/Koror"                       0.0909    0.7017    0.5000
+   331 "Pago Pago Intl"                         0.3697    0.9090    0.5000
+   332 "West Tinian"                            0.1473    0.6288    0.5000

--- a/result.txt
+++ b/result.txt
@@ -1,7 +1,13 @@
 avg degree:12.81(edges_num*2/node_num）
 top10 biggest nodes by degree:[('118', 139), ('261', 118), ('255', 101), ('182', 94), ('152', 94), ('230', 87), ('166', 85), ('67', 78), ('112', 70), ('201', 68)]
+
 avg path length:2.7381247042550867(assume adjacent distances are all 1)
+avg path length:1849.7179(with distance amplified 9000 times, miles not kilometers; note that the east-west direct distance in the US is about 2500 miles)
 diameter:6(assume adjacent distances are all 1)
+diameter:7867.5990(with distance amplified 9000 times)
+if consider distance, the farthest two are node 68(1 is beginning) and 330, which belongs to 帕劳(在西太平洋，当时由美国托管) and 缅因州（美国东北角）
+if not consider distance, the farthest two are node 9(1 is beginning) and 332，which belongs to Alaska and an western island near Philippines！！！
+
 global clustering coeff:0.6252172491625031
 
 max_coreness:26

--- a/result_9_9.txt
+++ b/result_9_9.txt
@@ -1,5 +1,0 @@
-avg degree:12.81(edges_num*2/node_num）
-top10 biggest nodes:[('118', 139), ('261', 118), ('255', 101), ('182', 94), ('152', 94), ('230', 87), ('166', 85), ('67', 78), ('112', 70), ('201', 68)]
-avg path length:2.7381247042550867(assume adjacent distances are all 1)
-diameter:6(assume adjacent distances are all 1)
-global clustering coeff:0.6252172491625031

--- a/test1.py
+++ b/test1.py
@@ -1,6 +1,7 @@
 import math
 import numpy as np
 from matplotlib import pyplot as plt 
+from math import sqrt
 
 def read_file(filename,normalize_freq=True):
     #读出node-edge，并存储在邻接矩阵中；该邻接矩阵先不考虑边的权值（即机场距离）；0代表自己与自己，math.inf代表不邻接
@@ -73,7 +74,7 @@ def floyd_easy(W):
                 D[i][j]=min(D[i][j],D[i][k]+D[k][j])
     return D
 
-def get_avg_path_length(adjacent):
+def get_avg_path_length(adjacent,index=False):
     #计算出avg_(shortest)_path_length以及网络直径
     #adjacent可以是不考虑距离，也可以是考虑距离的
     path_length=0
@@ -83,7 +84,10 @@ def get_avg_path_length(adjacent):
         for j in range(i+1,332):
             path_length+=D[i][j]
     avg_path_length=2*float(path_length)/(332*(332-1))
-    return diameter,avg_path_length
+    if index==False:
+        return diameter,avg_path_length
+    else:
+        return np.unravel_index(np.array(D).argmax(), np.array(D).shape)
 
 def draw_degree(inp,topk,draw_distribution=True):
     #当第二个参数为真的时候，画分布图；否则按顺序画每个节点度的柱状图
@@ -147,8 +151,10 @@ def clustering_coeff(adjacent):
 def draw_cluster():
     pass
 
-def get_node_name_distance(filename):
+def get_node_name_distance(filename,rate=9000):
 #带距离的邻接矩阵
+#rate代表距离要乘的系数，考虑到小数距离太小；英里为单位
+    D=[[math.inf for i in range(332)] for j in range(332)]
     with open (filename) as f:
         useful_line=[]
         lines=f.readlines()
@@ -159,6 +165,15 @@ def get_node_name_distance(filename):
             useful_line.append([line[0],line[1]])
             tmp=line[2].split()
             useful_line[index].extend(tmp)
+        for i in range(332):
+            for j in range(i,332):
+                if i==j:
+                    D[i][j]=float(0.0)
+                else:
+                    D[i][j]=rate*sqrt((float(useful_line[i][2])-float(useful_line[j][2]))**2+(float(useful_line[i][3])-float(useful_line[j][3]))**2)
+                    D[j][i]=rate*sqrt((float(useful_line[i][2])-float(useful_line[j][2]))**2+(float(useful_line[i][3])-float(useful_line[j][3]))**2)
+
+    return useful_line,D
 
 
 adj,freq,fn=read_file('inf-USAir97.mtx')
@@ -166,5 +181,6 @@ adj,freq,fn=read_file('inf-USAir97.mtx')
 #degree_result=get_degree(adj)
 #draw_degree(degree_result[3],degree_result[1],False)
 #cluster_result=clustering_coeff(adj)
+#u_l,D=get_node_name_distance('node_info.txt')
 
-get_node_name_distance('node_info.txt')
+


### PR DESCRIPTION
1. 读取node_info.txt，返回带距离的邻接矩阵（根据实际情况，距离放大9000倍，与实际情况相近）
2. 带距离的邻接矩阵计算直径和平均最短路径，结果更新在result.txt
3. 找到一份带路径计算的Floyd算法代码floyd_with_path，备用